### PR TITLE
Add option to include pre-existing SGs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_opensearch_domain" "opensearch" {
     for_each = var.inside_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
-      security_group_ids = [aws_security_group.es[0].id]
+      security_group_ids = [var.sg_ids, aws_security_group.es[0].id]
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -236,3 +236,9 @@ variable "tags" {
   type        = map(any)
   default     = {}
 }
+
+variable "sg_ids"{
+  type        = string
+  description = "Use any pre-existing SGs."
+  default     = ""
+}


### PR DESCRIPTION
provides the option to add pre-existing security groups that was created before / outside of this module