### PR TITLE
Fix availability_zone_count typo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,9 +108,9 @@ resource "aws_opensearch_domain" "opensearch" {
     warm_type                = try(var.cluster_config["warm_type"], false) ? try(var.cluster_config["warm_type"], null) : null
     zone_awareness_enabled   = try(var.cluster_config["zone_awareness_enabled"], false)
     dynamic "zone_awareness_config" {
-      for_each = try(var.cluster_config["avability_zone_count"], 1) > 1 && try(var.cluster_config["zone_awareness_enabled"], false) ? [1] : []
+      for_each = try(var.cluster_config["availability_zone_count"], 1) > 1 && try(var.cluster_config["zone_awareness_enabled"], false) ? [1] : []
       content {
-        availability_zone_count = try(var.cluster_config["avability_zone_count"], 1)
+        availability_zone_count = try(var.cluster_config["availability_zone_count"], 1)
       }
     }
   }


### PR DESCRIPTION
This fixes a typo I have found in the map lookup for "availability_zone_count" meaning the variable was ignored.