### PR TITLE
fix: Security groups adding empty string to array

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_opensearch_domain" "opensearch" {
     for_each = var.inside_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
-      security_group_ids = [var.sg_ids, aws_security_group.es[0].id]
+      security_group_ids = concat(var.sg_id == "" ? [] : [var.sg_id], [aws_security_group.es[0].id])
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/cyberlabrs/terraform-aws-opensearch/assets/115919235/f6de0a8e-33cf-4c61-bc87-cddb918334d4)

There was an issue where an empty security group would always be added to the opensearch-domain's security group list.

This happens if var.sg_ids is not passed
Tweaked the variable interpolation to fix this

Made sure it was backwards compatible.  You can still pass an empty var for `sg_ids`
