### PR TITLE
feat: Add master username output

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ No modules.
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
 | <a name="output_identity_pool_id"></a> [identity\_pool\_id](#output\_identity\_pool\_id) | Cognito identity pool ID |
 | <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | Domain-specific endpoint for kibana without https scheme |
+| <a name="output_os_user_name"></a> [os\_user_name](#output\_os\_user_name) | Master username for OpenSearch |
 | <a name="output_os_password"></a> [os\_password](#output\_os\_password) | Master user password for OpenSearch |
 | <a name="output_tags_all"></a> [tags\_all](#output\_tags\_all) | Map of tags assigned to the resource, including those inherited from the provider |
 | <a name="output_user_pool_id"></a> [user\_pool\_id](#output\_user\_pool\_id) | Cognito user pool ID |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,9 @@
+output "os_user_name" {
+  value       = var.master_user_name
+  description = "Master username for OpenSearch"
+  sensitive   = true
+}
+
 output "os_password" {
   value       = try(random_password.password[0].result, null)
   description = "Master user password for OpenSearch"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "os_user_name" {
-  value       = var.master_user_name
+  value       = var.internal_user_database_enabled ? var.master_user_name : null
   description = "Master username for OpenSearch"
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,13 +10,13 @@ variable "engine_version" {
 }
 
 variable "name" {
-  description = "Name of OpenSerach domain and suffix of all other resources."
+  description = "Name of OpenSearch domain and suffix of all other resources."
   type        = string
 }
 
 
 variable "master_user_name" {
-  description = "Master username for accessing OpenSerach."
+  description = "Master username for accessing OpenSearch."
   type        = string
   default     = "admin"
 }
@@ -102,7 +102,7 @@ variable "subnet_ids" {
 }
 
 variable "inside_vpc" {
-  description = "Openserach inside VPC."
+  description = "OpenSearch inside VPC."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This PR provides the output for the OpenSearch Master Username. I also fixed a few typos in some variable descriptions that used "OpenSerach" instead of "OpenSearch".